### PR TITLE
feat(mail): 更好的全自定义化邮箱通知配置

### DIFF
--- a/app/pages/notification.vue
+++ b/app/pages/notification.vue
@@ -288,86 +288,52 @@
           <Icon name="heroicons:envelope" class="w-5 h-5 inline-block mr-2 text-primary-500" />
           Email 配置
         </h2>
-
         <div class="space-y-4">
-          <!-- 邮件服务商 -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              邮件服务商 <span class="text-red-500">*</span>
-            </label>
-            <input
-              v-model="config.email.service"
-              type="text"
-              class="input"
-              placeholder="例如: QQ、126、163、Gmail"
-            />
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              支持列表: <a href="https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json" target="_blank" class="text-primary-500 hover:underline">点击查询</a>
-            </p>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">SMTP Host <span class="text-red-500">*</span></label>
+            <input v-model="config.email.SMTP_HOST" type="text" class="input" placeholder="SMTP 服务器地址" />
           </div>
-
-          <!-- 发件人邮箱 -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              发件人邮箱 <span class="text-red-500">*</span>
-            </label>
-            <input
-              v-model="config.email.user"
-              type="email"
-              class="input"
-              placeholder="your-email@example.com"
-            />
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              用于发送通知的邮箱地址
-            </p>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">SMTP Port <span class="text-red-500">*</span></label>
+            <input v-model="config.email.SMTP_PORT" type="number" class="input" placeholder="SMTP 端口" />
           </div>
-
-          <!-- 邮箱授权码 -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              邮箱授权码/密码 <span class="text-red-500">*</span>
-            </label>
-            <input
-              v-model="config.email.pass"
-              type="password"
-              class="input"
-              placeholder="邮箱授权码或密码"
-            />
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              大多数邮箱需要使用授权码而非登录密码，请在邮箱设置中获取
-            </p>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">SMTP User <span class="text-red-500">*</span></label>
+            <input v-model="config.email.SMTP_USER" type="text" class="input" placeholder="SMTP 用户名/邮箱" />
           </div>
-
-          <!-- 收件人邮箱 -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              收件人邮箱
-            </label>
-            <input
-              v-model="config.email.to"
-              type="email"
-              class="input"
-              placeholder="留空则发送给自己"
-            />
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              接收通知的邮箱地址，留空则发送给发件人邮箱
-            </p>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">SMTP Password <span class="text-red-500">*</span></label>
+            <input v-model="config.email.SMTP_PASSWORD" type="password" class="input" placeholder="SMTP 密码/授权码" />
           </div>
-
-          <!-- 测试按钮 -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">发件人 (From)</label>
+            <input v-model="config.email.SMTP_SENDER" type="text" class="input" placeholder="可选，默认与用户名一致" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">收件人 (To)</label>
+            <input v-model="config.email.SMTP_TO" type="text" class="input" placeholder="可选，默认与用户名一致" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">安全连接 (SSL/TLS)</label>
+            <select v-model="config.email.SMTP_SECURE" class="input">
+              <option value="none">否</option>
+              <option value="ssl">SSL</option>
+              <option value="tls">TLS/STARTTLS</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">忽略证书错误</label>
+            <select v-model="config.email.SMTP_INSECURE_IGNORE" class="input">
+              <option :value="false">否</option>
+              <option :value="true">是</option>
+            </select>
+          </div>
           <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
-            <button
-              type="button"
-              @click="testEmail"
-              class="btn-secondary"
-              :disabled="testingEmail || !config.email.service || !config.email.user || !config.email.pass"
-            >
+            <button type="button" @click="testEmail" class="btn-secondary" :disabled="testingEmail || !config.email.SMTP_HOST || !config.email.SMTP_PORT || !config.email.SMTP_USER || !config.email.SMTP_PASSWORD">
               <Icon name="heroicons:paper-airplane" class="w-4 h-4 mr-2" />
               {{ testingEmail ? '测试中...' : '发送测试通知' }}
             </button>
-            <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
-              点击发送一条测试通知，验证邮件配置是否正确
-            </p>
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">点击发送一条测试通知，验证邮件配置是否正确</p>
           </div>
         </div>
       </div>
@@ -469,10 +435,15 @@ const config = reactive({
     chatId: ''
   },
   email: {
-    service: '',
-    user: '',
-    pass: '',
-    to: ''
+    SMTP_HOST: '',
+    SMTP_PORT: '',
+    SMTP_USER: '',
+    SMTP_PASSWORD: '',
+    SMTP_SENDER: '',
+    SMTP_TO: '',
+    SMTP_SECURE: false,
+    SMTP_REQUIRE_TLS: false,
+    SMTP_INSECURE_IGNORE: false
   },
   serverchan: {
     sendKey: ''
@@ -520,6 +491,14 @@ async function fetchConfig() {
 
     if (response.success) {
       Object.assign(config, response.data)
+      // 修正安全连接下拉框的显示
+      if (config.email.SMTP_SECURE === true || config.email.SMTP_SECURE === 'true') {
+        config.email.SMTP_SECURE = 'ssl'
+      } else if ((config.email.SMTP_SECURE === false || config.email.SMTP_SECURE === 'false') && (config.email.SMTP_REQUIRE_TLS === true || config.email.SMTP_REQUIRE_TLS === 'true')) {
+        config.email.SMTP_SECURE = 'tls'
+      } else {
+        config.email.SMTP_SECURE = 'none'
+      }
       // 同步 headers 到 JSON 字符串
       headersJson.value = JSON.stringify(config.webhook.headers || {}, null, 2)
     }
@@ -540,12 +519,35 @@ async function saveConfig() {
     toastStore.error('请求头 JSON 格式错误')
     return
   }
-
+  let secure = false
+  let requireTLS = false
+  let port = Number(config.email.SMTP_PORT)
+  if (config.email.SMTP_SECURE === 'ssl') {
+    secure = true
+    requireTLS = false
+    if (port === 0 || isNaN(port)) port = 465
+  } else if (config.email.SMTP_SECURE === 'tls') {
+    secure = false
+    requireTLS = true
+    if (port === 0 || isNaN(port)) port = 587
+  } else {
+    secure = false
+    requireTLS = false
+  }
+  const emailConfig = {
+    ...config.email,
+    SMTP_SECURE: secure,
+    SMTP_REQUIRE_TLS: requireTLS,
+    SMTP_PORT: port
+  }
   saving.value = true
   try {
     const response = await $fetch('/api/notification', {
       method: 'PUT',
-      body: config,
+      body: {
+        ...config,
+        email: emailConfig
+      },
       headers: authStore.authHeader
     })
 
@@ -631,18 +633,38 @@ async function testTelegram() {
 
 // 测试 Email
 async function testEmail() {
-  if (!config.email.service || !config.email.user || !config.email.pass) {
+  if (!config.email.SMTP_HOST || !config.email.SMTP_PORT || !config.email.SMTP_USER || !config.email.SMTP_PASSWORD) {
     toastStore.error('请先填写完整的邮件配置')
     return
   }
-
+  let secure = false
+  let requireTLS = false
+  let port = Number(config.email.SMTP_PORT)
+  if (config.email.SMTP_SECURE === 'ssl') {
+    secure = true
+    requireTLS = false
+    if (port === 0 || isNaN(port)) port = 465
+  } else if (config.email.SMTP_SECURE === 'tls') {
+    secure = false
+    requireTLS = true
+    if (port === 0 || isNaN(port)) port = 587
+  } else {
+    secure = false
+    requireTLS = false
+  }
+  const emailConfig = {
+    ...config.email,
+    SMTP_SECURE: secure,
+    SMTP_REQUIRE_TLS: requireTLS,
+    SMTP_PORT: port
+  }
   testingEmail.value = true
   try {
     const response = await $fetch('/api/notification/test', {
       method: 'POST',
       body: {
         method: 'email',
-        email: config.email
+        email: emailConfig
       },
       headers: authStore.authHeader
     })

--- a/server/api/notification/index.put.js
+++ b/server/api/notification/index.put.js
@@ -35,6 +35,19 @@ export default defineEventHandler(async (event) => {
     // 获取 telegram、email 和 serverchan 配置
     const { telegram, email, serverchan } = body
 
+    // 构建 email 配置对象，支持 SMTP 相关字段
+    const emailConfig = {
+      SMTP_HOST: email?.SMTP_HOST || '',
+      SMTP_PORT: email?.SMTP_PORT || '',
+      SMTP_USER: email?.SMTP_USER || '',
+      SMTP_PASSWORD: email?.SMTP_PASSWORD || '',
+      SMTP_SENDER: email?.SMTP_SENDER || '',
+      SMTP_SECURE: email?.SMTP_SECURE || false,
+      SMTP_REQUIRE_TLS: email?.SMTP_REQUIRE_TLS || false,
+      SMTP_INSECURE_IGNORE: email?.SMTP_INSECURE_IGNORE || false,
+      SMTP_TO: email?.SMTP_TO || ''
+    }
+
     // 构建配置对象
     const config = {
       enabled: !!enabled,
@@ -61,12 +74,7 @@ export default defineEventHandler(async (event) => {
         token: telegram?.token || '',
         chatId: telegram?.chatId || ''
       },
-      email: {
-        service: email?.service || '',
-        user: email?.user || '',
-        pass: email?.pass || '',
-        to: email?.to || ''
-      },
+      email: emailConfig,
       serverchan: {
         sendKey: serverchan?.sendKey || ''
       }

--- a/server/utils/notification.js
+++ b/server/utils/notification.js
@@ -64,10 +64,14 @@ export function getDefaultNotificationConfig() {
     },
     // Email 配置
     email: {
-      service: '',  // 邮件服务商，如 'gmail', 'qq', '163' 等
-      user: '',     // 发件人邮箱
-      pass: '',     // 邮箱授权码/密码
-      to: ''        // 收件人邮箱（可选，默认发送给自己）
+      SMTP_HOST: '',
+      SMTP_PORT: '',
+      SMTP_USER: '',
+      SMTP_PASSWORD: '',
+      SMTP_SENDER: '',
+      SMTP_SECURE: false,
+      SMTP_INSECURE_IGNORE: false,
+      SMTP_TO: ''
     },
     // Server酱 配置
     serverchan: {
@@ -463,24 +467,31 @@ function generateEmailTemplate(content) {
  */
 async function sendEmailNotification(config, payload) {
   const { email } = config
-
-  if (!email.service || !email.user || !email.pass) {
+  if (!email.SMTP_HOST || !email.SMTP_PORT || !email.SMTP_USER || !email.SMTP_PASSWORD) {
     console.warn('[Notification] Email 配置不完整')
-    return { success: false, error: 'Email 配置不完整（需要 service、user、pass）' }
+    return { success: false, error: 'Email 配置不完整（需要 SMTP_HOST、SMTP_PORT、SMTP_USER、SMTP_PASSWORD）' }
   }
-
   try {
     console.log('[Notification] 邮件通知预发送:', payload.title)
-
-    // 创建邮件传输器
     const transporter = nodemailer.createTransport({
-      service: email.service,
+      host: email.SMTP_HOST,
+      port: Number(email.SMTP_PORT),
+      secure: email.SMTP_SECURE === true || email.SMTP_SECURE === 'true',
+      requireTLS: email.SMTP_REQUIRE_TLS === true || email.SMTP_REQUIRE_TLS === 'true',
       auth: {
-        user: email.user,
-        pass: email.pass
-      }
+        user: email.SMTP_USER,
+        pass: email.SMTP_PASSWORD
+      },
+      tls: email.SMTP_INSECURE_IGNORE ? { rejectUnauthorized: false } : undefined,
+      logger: true,
+      debug: true
     })
-
+    transporter.on('log', info => {
+      console.log('[Nodemailer][log]', info)
+    })
+    transporter.on('error', err => {
+      console.error('[Nodemailer][error]', err)
+    })
     // 检查是否有有效的图片URL
     const imageUrl = payload.data?.url || payload.data?.imageUrl
     const hasValidImageUrl = isValidImageUrl(imageUrl)
@@ -526,11 +537,11 @@ async function sendEmailNotification(config, payload) {
     htmlContent += '</div>'
 
     // 收件人地址，默认发送给自己
-    const toAddress = email.to || email.user
+    const toAddress = email.SMTP_TO || email.SMTP_USER
 
     // 发送邮件
     await transporter.sendMail({
-      from: email.user,
+      from: email.SMTP_SENDER || email.SMTP_USER,
       to: toAddress,
       subject: `[EasyImg] ${payload.title}`,
       html: generateEmailTemplate(htmlContent)
@@ -539,8 +550,15 @@ async function sendEmailNotification(config, payload) {
     console.log('[Notification] 邮件通知发送成功:', payload.title)
     return { success: true }
   } catch (error) {
-    console.error('[Notification] 邮件发送失败:', error)
-    return { success: false, error: error.message }
+    let detail = error && typeof error === 'object' ? {
+      message: error.message,
+      code: error.code,
+      response: error.response,
+      command: error.command,
+      stack: error.stack
+    } : error
+    console.error('[Notification] 邮件发送失败:', detail)
+    return { success: false, error: error.message, detail }
   }
 }
 
@@ -782,7 +800,7 @@ export async function testTelegram(telegramConfig) {
 
     console.log('[Notification] Telegram 测试通知预发送')
 
-    const message = `*测试通知*\n这是一条测试通知，用于验证 Telegram 配置是否正确。\n\n_发送时间: ${new Date().toISOString()}_`
+    const message = `*测试通知*\n这是一条测试通知，���于验证 Telegram 配置是否正确。\n\n_发送时间: ${new Date().toISOString()}_`
 
     // 创建 Bot 实例，从环境变量读取 API 地址（用于反代）
     const botOptions = {}
@@ -807,49 +825,48 @@ export async function testTelegram(telegramConfig) {
  */
 export async function testEmail(emailConfig) {
   try {
-    if (!emailConfig.service || !emailConfig.user || !emailConfig.pass) {
-      return { success: false, error: '请提供完整的邮件配置（service、user、pass）' }
+    if (!emailConfig.SMTP_HOST || !emailConfig.SMTP_PORT || !emailConfig.SMTP_USER || !emailConfig.SMTP_PASSWORD) {
+      return { success: false, error: '请提供完整的邮件配置（SMTP_HOST、SMTP_PORT、SMTP_USER、SMTP_PASSWORD）' }
     }
-
-    console.log('[Notification] Email 测试通知预发送')
-
-    // 创建邮件传输器
     const transporter = nodemailer.createTransport({
-      service: emailConfig.service,
+      host: emailConfig.SMTP_HOST,
+      port: Number(emailConfig.SMTP_PORT),
+      secure: emailConfig.SMTP_SECURE === true || emailConfig.SMTP_SECURE === 'true',
+      requireTLS: emailConfig.SMTP_REQUIRE_TLS === true || emailConfig.SMTP_REQUIRE_TLS === 'true',
       auth: {
-        user: emailConfig.user,
-        pass: emailConfig.pass
-      }
+        user: emailConfig.SMTP_USER,
+        pass: emailConfig.SMTP_PASSWORD
+      },
+      tls: emailConfig.SMTP_INSECURE_IGNORE ? { rejectUnauthorized: false } : undefined,
+      logger: true,
+      debug: true
     })
-
-    // 收件人地址，默认发送给自己
-    const toAddress = emailConfig.to || emailConfig.user
-
-    const htmlContent = `
-      <div class="header">
-        <h1>测试通知</h1>
-      </div>
-      <div class="content">
-        <p>这是一条测试通知，用于验证邮件配置是否正确。</p>
-        <div class="info-item">
-          <span class="info-label">发送时间:</span>
-          <span class="info-value">${new Date().toISOString()}</span>
-        </div>
-      </div>
-    `
-
+    // 日志输出
+    transporter.on('log', info => {
+      console.log('[Nodemailer][log]', info)
+    })
+    transporter.on('error', err => {
+      console.error('[Nodemailer][error]', err)
+    })
+    const toAddress = emailConfig.SMTP_TO || emailConfig.SMTP_USER
+    const htmlContent = `<div class="header"><h1>测试通知</h1></div><div class="content"><p>这是一条测试通知，用于验证邮件配置是否正确。</p></div>`
     await transporter.sendMail({
-      from: emailConfig.user,
+      from: emailConfig.SMTP_SENDER || emailConfig.SMTP_USER,
       to: toAddress,
       subject: '[EasyImg] 测试通知',
-      html: generateEmailTemplate(htmlContent)
+      html: htmlContent
     })
-
-    console.log('[Notification] Email 测试通知发送成功')
-    return { success: true, message: '测试通知发送成功' }
+    return { success: true }
   } catch (error) {
-    console.error('[Notification] Email 测试失败:', error)
-    return { success: false, error: error.message }
+    // 返回详细 nodemailer 错误
+    let detail = error && typeof error === 'object' ? {
+      message: error.message,
+      code: error.code,
+      response: error.response,
+      command: error.command,
+      stack: error.stack
+    } : error
+    return { success: false, error: error.message, detail }
   }
 }
 


### PR DESCRIPTION
在此分支中，实现了可全自定义配置的邮箱通知。

先前基于平台的选择太局限，像自建的邮箱系统完全无法配置和支持。

现在，在选择 Email 通知后，支持配置如下内容，同时还支持发送测试邮件观察配置情况。

实测一切正常。

<img width="1402" height="1450" alt="image" src="https://github.com/user-attachments/assets/9fdf7ef2-8440-4233-841a-0d332e64deb3" />
